### PR TITLE
Code style, add template data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "forum": "https://community.contao.org/de"
     },
     "require":{
-        "php": ">=7.1",
+        "php": ">=7.4",
         "contao/core-bundle": "^4.13",
         "isotope/isotope-core": "^2.5",
         "mpdf/mpdf": "^8.0",

--- a/contao/dca/tl_iso_document.php
+++ b/contao/dca/tl_iso_document.php
@@ -12,32 +12,11 @@ declare(strict_types=1);
 
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use InspiredMinds\ContaoIsotopePdfTemplatesBundle\EventListener\DataContainer\IsoDocumentListener;
+use Isotope\Backend;
 
 $GLOBALS['TL_DCA']['tl_iso_document']['config']['onload_callback'][] = [IsoDocumentListener::class, 'onLoadCallback'];
 
 $GLOBALS['TL_DCA']['tl_iso_document']['palettes']['template'] = $GLOBALS['TL_DCA']['tl_iso_document']['palettes']['standard'];
-
-$GLOBALS['TL_DCA']['tl_iso_document']['fields']['pdfHeaderTemplate'] = [
-    'exclude'               => true,
-    'inputType'             => 'select',
-    'default'               => 'iso_document_header',
-    'options_callback'      => function() {
-        return \Isotope\Backend::getTemplates('iso_document_');
-    },
-    'eval'                  => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
-    'sql'                   => "varchar(64) NOT NULL default ''",
-];
-
-$GLOBALS['TL_DCA']['tl_iso_document']['fields']['pdfFooterTemplate'] = [
-    'exclude'               => true,
-    'inputType'             => 'select',
-    'default'               => 'iso_document_footer',
-    'options_callback'      => function() {
-        return \Isotope\Backend::getTemplates('iso_document_');
-    },
-    'eval'                  => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
-    'sql'                   => "varchar(64) NOT NULL default ''",
-];
 
 $GLOBALS['TL_DCA']['tl_iso_document']['fields']['usePdfTemplate'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_iso_document']['usePdfTemplate'],
@@ -187,6 +166,26 @@ $GLOBALS['TL_DCA']['tl_iso_document']['fields']['pdfAuthor'] = [
     'inputType' => 'text',
     'eval' => ['tl_class' => 'w50', 'maxlength' => 128],
     'sql' => ['type' => 'string', 'length' => 128, 'default' => ''],
+];
+
+$GLOBALS['TL_DCA']['tl_iso_document']['fields']['pdfHeaderTemplate'] = [
+    'exclude' => true,
+    'inputType' => 'select',
+    'options_callback' => static function (): array {
+        return Backend::getTemplates('iso_document_');
+    },
+    'eval' => ['includeBlankOption' => true, 'chosen' => true, 'tl_class' => 'w50'],
+    'sql' => "varchar(64) NOT NULL default ''",
+];
+
+$GLOBALS['TL_DCA']['tl_iso_document']['fields']['pdfFooterTemplate'] = [
+    'exclude' => true,
+    'inputType' => 'select',
+    'options_callback' => static function (): array {
+        return Backend::getTemplates('iso_document_');
+    },
+    'eval' => ['includeBlankOption' => true, 'chosen' => true, 'tl_class' => 'w50'],
+    'sql' => "varchar(64) NOT NULL default ''",
 ];
 
 $GLOBALS['TL_DCA']['tl_iso_document']['palettes']['__selector__'][] = 'usePdfTemplate';

--- a/contao/languages/en/tl_iso_document.php
+++ b/contao/languages/en/tl_iso_document.php
@@ -36,4 +36,3 @@ $GLOBALS['TL_LANG']['tl_iso_document']['pdfCreator'] = ['Creator', 'Define the c
 $GLOBALS['TL_LANG']['tl_iso_document']['pdfAuthor'] = ['Author', 'Define the author of the PDF here. Otherwise the URL will be used by default.'];
 $GLOBALS['TL_LANG']['tl_iso_document']['pdfHeaderTemplate'] = ['PDF header', 'If a header is desired in the PDF, the template can be selected here'];
 $GLOBALS['TL_LANG']['tl_iso_document']['pdfFooterTemplate'] = ['PDF footer', 'If a footer is desired in the PDF, the template can be selected here'];
-

--- a/src/Isotope/Model/Document/Template.php
+++ b/src/Isotope/Model/Document/Template.php
@@ -83,19 +83,15 @@ class Template extends \Isotope\Model\Document\Standard
             'margin_top' => (int) ($margin['top'] ?? (\defined('PDF_MARGIN_TOP') ? PDF_MARGIN_TOP : 10)),
             'margin_bottom' => (int) ($margin['bottom'] ?? (\defined('PDF_MARGIN_BOTTOM') ? PDF_MARGIN_BOTTOM : 10)),
         ]);
-       
+
         // Add PDF Header
         if ($this->pdfHeaderTemplate) {
-            $template = new \Isotope\Template($this->pdfHeaderTemplate);
-            $buffer = $template->parse();
-            $pdf->SetHTMLHeader($buffer);
+            $pdf->SetHTMLHeader($this->parseCustomTemplate($this->pdfHeaderTemplate, $objCollection, $arrTokens));
         }
 
         // Add PDF Footer
         if ($this->pdfFooterTemplate) {
-            $template = new \Isotope\Template($this->pdfFooterTemplate);
-            $buffer = $template->parse();
-            $pdf->SetHTMLFooter($buffer);
+            $pdf->SetHTMLFooter($this->parseCustomTemplate($this->pdfFooterTemplate, $objCollection, $arrTokens));
         }
 
         // Set default font and size
@@ -151,5 +147,20 @@ class Template extends \Isotope\Model\Document\Standard
         }
 
         return $pdf;
+    }
+
+    /**
+     * Parses additional custom templates with the same data as the main template.
+     */
+    protected function parseCustomTemplate(string $templateName, IsotopeProductCollection $collection, array $tokens): string
+    {
+        $currentTemplate = $this->documentTpl;
+        $this->documentTpl = $templateName;
+
+        $buffer = $this->generateTemplate($collection, $tokens);
+
+        $this->documentTpl = $currentTemplate;
+
+        return $buffer;
     }
 }


### PR DESCRIPTION
This adds a few changes to your PR:

* General code style changes.
* New fields added to the bottom of the DCA, rather than the top.
* Removed the default from the new fields, but kept the example templates.
* Even though the templates are named `iso_document_*` they did not actually contain _any_ data with which you would expected to be able to work with in those templates. I have changed the implementation so that the header and footer template receives the same data as the main template.